### PR TITLE
add in basic logic for disqus comments

### DIFF
--- a/calisphere/templates/calisphere/itemView.html
+++ b/calisphere/templates/calisphere/itemView.html
@@ -19,6 +19,16 @@
   {% endblock %}
 </div>
 
+{% if item.parsed_collection_data.0.disqus_shortname %}
+<div style="display: block; clear: both;">
+  <div id="disqus_thread"></div>
+  <div id="disqus_loader" style="text-align: center">
+    <button onclick='$.ajaxSetup({cache:true});$.getScript("http://{{ item.parsed_collection_data.0.disqus_shortname}}.disqus.com/embed.js");$.ajaxSetup({cache:false});$("#disqus_loader").remove();'>Load Disqus Comments</button>
+  </div>
+</div>
+{% endif %}
+
+
 <div class="related-coll--search-results-page" id="js-relatedCollections">
   {% include "calisphere/related-collections.html" %}
 </div>

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -49,6 +49,7 @@ UCLDC_REGISTRY_URL = getenv('UCLDC_REGISTRY_URL',
 
 UCLDC_FRONT = getenv('UCLDC_FRONT', '')
 UCLDC_REDIS_URL = getenv('UCLDC_REDIS_URL', False)
+UCLDC_DISQUS = getenv('UCLDC_DISQUS', 'test')  # set to 'prod' to use the prod disqus shortcode value
 
 EMAIL_BACKEND = getenv('EMAIL_BACKEND',
                           'django.core.mail.backends.console.EmailBackend')


### PR DESCRIPTION
uses http://blog.yjl.im/2012/04/let-your-readers-decide-when-to-load.html

the value for disqus shortcode is read from the registry collection record `disqus_shortname_prod` or `disqus_shortname_test`

set `UCLDC_DISQUS` to 'prod' (or kicks in when `UCLDC_FRONT` is `https://calisphere.org/`) to use `disqus_shortname_prod` -- otherwise reads `disqus_shortname_test`